### PR TITLE
Refactor for safer outputPath handling

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -3,22 +3,22 @@ const extractId = require('./lib/extractMatches.js');
 const buildEmbed = require('./lib/buildEmbed.js');
 const pluginDefaults = require('./lib/pluginDefaults.js');
 
-module.exports = function(eleventyConfig, options) {
+module.exports = function (eleventyConfig, options) {
   const pluginConfig = Object.assign(pluginDefaults, options);
   eleventyConfig.addTransform("embedInstagram", async (content, outputPath) => {
-    if (!outputPath.endsWith(".html")) {
+    if (outputPath && outputPath.endsWith(".html")) {
+      let matches = patternPresent(content);
+      if (!matches) {
+        return content;
+      }
+      // index is used to limit the number of script tags added to each page to one
+      matches.forEach(function (stringToReplace, index) {
+        let mediaId = extractId(stringToReplace);
+        let embedCode = buildEmbed(mediaId, pluginConfig, index);
+        content = content.replace(stringToReplace, embedCode);
+      });
       return content;
     }
-    let matches = patternPresent(content);
-    if (!matches) {
-      return content;
-    }
-    // index is used to limit the number of script tags added to each page to one
-    matches.forEach(function(stringToReplace, index) {
-      let mediaId = extractId(stringToReplace);
-      let embedCode = buildEmbed(mediaId, pluginConfig, index);
-      content = content.replace(stringToReplace, embedCode);
-    });
     return content;
   });
 };


### PR DESCRIPTION
This PR refactors `outputPath` checking to better handle `null` cases (which can happen with XML files).