### PR TITLE
Safer whitespace handling in regular expressions

### DIFF
--- a/lib/extractMatches.js
+++ b/lib/extractMatches.js
@@ -1,5 +1,29 @@
-const pattern = /<p>\s*(?:<a.*>)?\s*(?:https?:\/\/)?(?:w{3}\.)?(?:instagram\.com)\/(?:p\/)?([0-9a-zA-Z-_]{11})(?:\S*)(?:\s*)(?:<\/a>)?(?:\s*)?<\/p>/;
+/**
+ * Regular expression to extract the Instagram ID from the URL.
+ * 
+ * Why out[3]?
+ * -----------
+ * `\s*`, necessary to accomodate arbitrary whitespace, is 
+ * vulnerable to catastrophic backtracking that can lead to 
+ * regular expression denial-of-service. JS/Node doesn’t support
+ * RegEx atomic groups like other languages do. The workaround
+ * requires capturing groups for whitespace with positive
+ * lookaheads:
+ * 
+ * https://blog.stevenlevithan.com/archives/mimic-atomic-groups
+ * 
+ * Until we formally drop support for Node 8 and can start using
+ * named capture groups, we have to count matches in the returned
+ * RegEx array.
+ *  
+ * out[0]           = full match
+ * out[1], out[2]   = optional whitespace characters 
+ * out[3]           = Instagram media ID
+ * out[4], out[5]   = optional whitespace characters
+ */
+
+const pattern = /<p>(?=(\s*))\1(?:<a [^>]*?>)??(?=(\s*))\2(?:https?:\/\/)?(?:w{3}\.)?(?:instagram\.com)\/(?:p\/)?([0-9a-zA-Z-_]{11})(?:\S*)(?=(\s*))\4(?:<\/a>)?(?=(\s*))\5<\/p>/;
 module.exports = function(str) {
-  let [, out ] = pattern.exec(str);
-  return out;
+  let out = pattern.exec(str);
+  return out[3];
 }

--- a/lib/spotPattern.js
+++ b/lib/spotPattern.js
@@ -1,4 +1,4 @@
-const pattern = /<p>\s*(?:<a(.*)>)?\s*(?:https?:\/\/)?(?:w{3}\.)?(?:instagram\.com)\/(?:p\/)(?:[0-9a-zA-Z_-]{11})\S*\s*(?:<\/a>)?\s*?<\/p>/g;
+const pattern = /<p>(?=(\s*))\1(?:<a [^>]*?>)??(?=(\s*))\2(?:https?:\/\/)?(?:w{3}\.)?(?:instagram\.com\/p\/)(?:[0-9a-zA-Z_-]{11})[^\s]*?(?=(\s*))\3(?:<\/a>)??(?=(\s*))\4<\/p>/g;
 module.exports = function(str) {
   return str.match(pattern);
 }

--- a/test.js
+++ b/test.js
@@ -50,6 +50,14 @@ validStrings.forEach(function(obj){
     </p>`;
     t.truthy(patternPresent(withLinksAndWhitespace));
   });
+  test(`String is valid: ${obj.type} with links and whitespace surrounding wrapping paragraph`, t => {
+    let withLinksAndWhitespace = `   <p>
+      <a href="">
+        ${obj.str}
+      </a>
+    </p>   `;
+    t.truthy(patternPresent(withLinksAndWhitespace));
+  });
 });
 /**
  * Ensure that valid strings produce the expected media ID as output


### PR DESCRIPTION
CodeQL flagged the potential for [Regular Expression Denial of Service](https://owasp.org/www-community/attacks/Regular_expression_Denial_of_Service_-_ReDoS) incidents in the two regex files that parse for Instagram URLs and extract the necessary embed data. This PR modifies those regular expressions to remove this vulnerability.

The potential for exploiting this maliciously is, in practice, very small in the case of Eleventy; you're probably building from markdown files that you control, and not arbitrary input from unknown users. Still, the modifications here make the regexes more specific, more predictable, and more performant. The regex remains compatible with all the currently [supported test cases and URL patterns](https://github.com/gfscott/eleventy-plugin-embed-instagram/blob/main/test.js#L8:L16).

References:
- [CWE-1333](https://cwe.mitre.org/data/definitions/1333.html)
- [OWASP report on ReDoS](https://owasp.org/www-community/attacks/Regular_expression_Denial_of_Service_-_ReDoS)
- More about [catastrophic backtracking](https://www.regular-expressions.info/catastrophic.html)
- [Mimicking safer atomic groups in JavaScript](https://blog.stevenlevithan.com/archives/mimic-atomic-groups)