### PR TITLE
Run CodeQL on all branches, and remove scheduling

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -11,14 +11,7 @@
 #
 name: "CodeQL"
 
-on:
-  push:
-    branches: [ main ]
-  pull_request:
-    # The branches below must be a subset of the branches above
-    branches: [ main ]
-  schedule:
-    - cron: '34 8 * * 2'
+on: [push, pull_request]
 
 jobs:
   analyze:


### PR DESCRIPTION
Scheduled runs don't make much sense for this codebase, and running only on main makes it hard to assess PRs.